### PR TITLE
chore: remove u-m-0 classes from pages

### DIFF
--- a/app/pages/contact.html
+++ b/app/pages/contact.html
@@ -20,10 +20,10 @@ slug: "/contact"
 <section class="l-section l-band">
   <div class="l-container l-grid l-grid--auto l-grid--gap-lg">
     <article class="c-card c-card--hover">
-      <h2 class="t-subtitle u-m-0">Algemeen</h2>
-      <p class="t-body u-m-0">E-mail: <a href="mailto:info@neder.ai">info@neder.ai</a></p>
-      <p class="t-body u-m-0">Locatie: Wijchen, Nederland</p>
-      <ul class="t-small u-text-muted u-m-0 u-mt-sm">
+      <h2 class="t-subtitle">Algemeen</h2>
+      <p class="t-body">E-mail: <a href="mailto:info@neder.ai">info@neder.ai</a></p>
+      <p class="t-body">Locatie: Wijchen, Nederland</p>
+      <ul class="t-small u-text-muted u-mt-sm">
         <li>KVK: t.b.c.</li>
         <li>RSIN: t.b.c.</li>
         <li>Tijdzone: Europa/Amsterdam</li>
@@ -31,14 +31,14 @@ slug: "/contact"
     </article>
 
     <article class="c-card c-card--hover">
-      <h2 class="t-subtitle u-m-0">Pers &amp; media</h2>
-      <p class="t-body u-m-0">E-mail: <a href="mailto:pers@neder.ai">pers@neder.ai</a></p>
-      <p class="t-small u-text-muted u-m-0">Logo &amp; basisinfo: <a href="/assets/presskit.zip">press kit</a></p>
+      <h2 class="t-subtitle">Pers &amp; media</h2>
+      <p class="t-body">E-mail: <a href="mailto:pers@neder.ai">pers@neder.ai</a></p>
+      <p class="t-small u-text-muted">Logo &amp; basisinfo: <a href="/assets/presskit.zip">press kit</a></p>
     </article>
 
     <article class="c-card c-card--hover">
-      <h2 class="t-subtitle u-m-0">Veilig melden</h2>
-      <p class="t-body u-m-0">Klokkenluiders: <a href="mailto:klokkenluiders@neder.ai">klokkenluiders@neder.ai</a></p>
+      <h2 class="t-subtitle">Veilig melden</h2>
+      <p class="t-body">Klokkenluiders: <a href="mailto:klokkenluiders@neder.ai">klokkenluiders@neder.ai</a></p>
       <div class="c-hero__actions u-mt-sm">
         <a class="c-btn" href="/klokkenluiders">Loket &amp; richtlijnen</a>
         <a class="c-btn c-btn--secondary" href="/keys/nederai-pubkey.asc" download>PGP-sleutel</a>
@@ -52,17 +52,17 @@ slug: "/contact"
   <div class="l-container l-switcher">
     <div class="l-stack">
       <h2 class="t-title">Afspraak maken</h2>
-      <p class="t-body u-m-0">Plan een (online) kennismaking of werkafspraak. Stuur je voorkeursdata en onderwerp mee.</p>
+      <p class="t-body">Plan een (online) kennismaking of werkafspraak. Stuur je voorkeursdata en onderwerp mee.</p>
       <div class="c-hero__actions u-mt-sm">
         <a class="c-btn" href="mailto:info@neder.ai?subject=Afspraak%20maken%20met%20NederAI">Mail voor afspraak</a>
       </div>
-      <p class="t-small u-text-muted u-m-0">Fase 1: planning via e-mail. Fase 2: formulier + agenda-koppeling.</p>
+      <p class="t-small u-text-muted">Fase 1: planning via e-mail. Fase 2: formulier + agenda-koppeling.</p>
     </div>
     <div class="l-stack">
       <div class="c-card">
-        <h3 class="t-subtitle u-m-0">Bezoekadres</h3>
-        <p class="t-body u-m-0">t.b.c. • Wijchen, Nederland</p>
-        <p class="t-small u-text-muted u-m-0">Bezoek uitsluitend op afspraak.</p>
+        <h3 class="t-subtitle">Bezoekadres</h3>
+        <p class="t-body">t.b.c. • Wijchen, Nederland</p>
+        <p class="t-small u-text-muted">Bezoek uitsluitend op afspraak.</p>
       </div>
     </div>
   </div>

--- a/app/pages/documenten.html
+++ b/app/pages/documenten.html
@@ -26,36 +26,36 @@ slug: "/documenten"
     <h2 class="t-title">Statuten &amp; Reglementen</h2>
     <div class="l-grid l-grid--auto l-grid--gap-lg">
       <article class="c-card c-card--hover">
-        <h3 class="t-subtitle u-m-0">Statuten</h3>
-        <p class="t-body u-m-0">Rechtspositie, doel en governance van NederAI.</p>
-        <p class="t-small u-text-muted u-m-0">PDF • v1.0</p>
+        <h3 class="t-subtitle">Statuten</h3>
+        <p class="t-body">Rechtspositie, doel en governance van NederAI.</p>
+        <p class="t-small u-text-muted">PDF • v1.0</p>
         <div class="c-hero__actions u-mt-sm">
           <a class="c-btn" href="/docs/statuten.pdf" download>Download</a>
         </div>
       </article>
 
       <article class="c-card c-card--hover">
-        <h3 class="t-subtitle u-m-0">Waardenverklaring</h3>
-        <p class="t-body u-m-0">Hoogste toetsingskader voor beleid en uitvoering.</p>
-        <p class="t-small u-text-muted u-m-0">HTML • actueel</p>
+        <h3 class="t-subtitle">Waardenverklaring</h3>
+        <p class="t-body">Hoogste toetsingskader voor beleid en uitvoering.</p>
+        <p class="t-small u-text-muted">HTML • actueel</p>
         <div class="c-hero__actions u-mt-sm">
           <a class="c-btn" href="/missie-en-waarden">Lees online</a>
         </div>
       </article>
 
       <article class="c-card c-card--hover">
-        <h3 class="t-subtitle u-m-0">Reglement bestuur</h3>
-        <p class="t-body u-m-0">Taken, vergaderingen, besluitvorming en verantwoording.</p>
-        <p class="t-small u-text-muted u-m-0">PDF • concept</p>
+        <h3 class="t-subtitle">Reglement bestuur</h3>
+        <p class="t-body">Taken, vergaderingen, besluitvorming en verantwoording.</p>
+        <p class="t-small u-text-muted">PDF • concept</p>
         <div class="c-hero__actions u-mt-sm">
           <a class="c-btn c-btn--secondary" href="/docs/reglement-bestuur.pdf" download>Download</a>
         </div>
       </article>
 
       <article class="c-card c-card--hover">
-        <h3 class="t-subtitle u-m-0">Klokkenluidersregeling</h3>
-        <p class="t-body u-m-0">Procedure voor melden en bescherming van melders.</p>
-        <p class="t-small u-text-muted u-m-0">In voorbereiding</p>
+        <h3 class="t-subtitle">Klokkenluidersregeling</h3>
+        <p class="t-body">Procedure voor melden en bescherming van melders.</p>
+        <p class="t-small u-text-muted">In voorbereiding</p>
         <div class="c-hero__actions u-mt-sm">
           <a class="c-btn c-btn--secondary" href="/klokkenluiders">Bekijk loket</a>
         </div>
@@ -78,7 +78,7 @@ slug: "/documenten"
       </tbody>
     </table>
     <div class="c-alert c-alert--info">
-      <p class="t-small u-m-0">Fase 1: handmatige upload van PDF. Fase 3: automatische publicatie met audittrail.</p>
+      <p class="t-small">Fase 1: handmatige upload van PDF. Fase 3: automatische publicatie met audittrail.</p>
     </div>
   </div>
 </section>
@@ -113,15 +113,15 @@ slug: "/documenten"
     <h2 class="t-title">Beleidsstukken &amp; Rapportages</h2>
     <div class="l-grid l-grid--auto l-grid--gap-lg">
       <article class="c-card c-card--hover">
-        <h3 class="t-subtitle u-m-0">Beleid & Strategie</h3>
-        <p class="t-body u-m-0">Richtlijnen, kaders en routekaarten.</p>
+        <h3 class="t-subtitle">Beleid & Strategie</h3>
+        <p class="t-body">Richtlijnen, kaders en routekaarten.</p>
         <div class="c-hero__actions u-mt-sm">
           <a class="c-btn c-btn--secondary" href="/docs/beleid-strategie.pdf" download>Download</a>
         </div>
       </article>
       <article class="c-card c-card--hover">
-        <h3 class="t-subtitle u-m-0">Toepassing Waardenverklaring</h3>
-        <p class="t-body u-m-0">Verslaglegging over toepassing in beleid en projecten.</p>
+        <h3 class="t-subtitle">Toepassing Waardenverklaring</h3>
+        <p class="t-body">Verslaglegging over toepassing in beleid en projecten.</p>
         <div class="c-hero__actions u-mt-sm">
           <a class="c-btn c-btn--secondary" href="/docs/waarden-toepassing.pdf" download>Download</a>
         </div>
@@ -135,8 +135,8 @@ slug: "/documenten"
   <div class="l-container l-switcher">
     <div class="l-stack">
       <h2 class="t-title">Open data</h2>
-      <p class="t-body u-m-0">Datasets en documenten voor hergebruik. Licentie: CC BY 4.0 tenzij anders vermeld.</p>
-      <ul class="t-small u-text-muted u-m-0 u-flex u-wrap u-gap-sm u-mt-sm">
+      <p class="t-body">Datasets en documenten voor hergebruik. Licentie: CC BY 4.0 tenzij anders vermeld.</p>
+      <ul class="t-small u-text-muted u-flex u-wrap u-gap-sm u-mt-sm">
         <li>CSV/JSON</li><li>Versiedatering</li><li>Checksum</li>
       </ul>
     </div>
@@ -155,7 +155,7 @@ slug: "/documenten"
             </tr>
           </tbody>
         </table>
-        <p class="t-small u-text-muted u-m-0">Fase 3: live API’s en automatische exports.</p>
+        <p class="t-small u-text-muted">Fase 3: live API’s en automatische exports.</p>
       </div>
     </div>
   </div>
@@ -166,7 +166,7 @@ slug: "/documenten"
   <div class="l-container l-switcher">
     <div class="l-stack">
       <h2 class="t-title">Vragen of ontbreekt er iets?</h2>
-      <p class="t-body u-m-0">Mail je verzoek; we streven naar snelle, publieke aanvulling.</p>
+      <p class="t-body">Mail je verzoek; we streven naar snelle, publieke aanvulling.</p>
       <div class="c-hero__actions">
         <a class="c-btn" href="/contact">Contact</a>
         <a class="c-btn c-btn--secondary" href="/samenwerken">Samenwerken</a>
@@ -174,7 +174,7 @@ slug: "/documenten"
     </div>
     <div class="l-stack">
       <div class="c-alert c-alert--info">
-        <p class="t-small u-m-0">Deze pagina is onderdeel van fase 1 (statisch). Integraties volgen in fase 2–3.</p>
+        <p class="t-small">Deze pagina is onderdeel van fase 1 (statisch). Integraties volgen in fase 2–3.</p>
       </div>
     </div>
   </div>

--- a/app/pages/home.html
+++ b/app/pages/home.html
@@ -32,20 +32,20 @@ slug: "/"
     <h2 class="t-title">Waar we voor staan</h2>
     <div class="l-grid l-grid--auto u-my-md">
       <article class="c-card c-card--hover">
-        <h3 class="t-subtitle u-m-0">Juridisch &amp; Governance</h3>
-        <p class="u-m-0 t-body">Transparantie, rechtsstatelijkheid, integriteit en anti-capture.</p>
+        <h3 class="t-subtitle">Juridisch &amp; Governance</h3>
+        <p class="t-body">Transparantie, rechtsstatelijkheid, integriteit en anti-capture.</p>
       </article>
       <article class="c-card c-card--hover">
-        <h3 class="t-subtitle u-m-0">Maatschappelijk &amp; Ethisch</h3>
-        <p class="u-m-0 t-body">Publiek belang boven private winst; inclusief, egalitair en duurzaam.</p>
+        <h3 class="t-subtitle">Maatschappelijk &amp; Ethisch</h3>
+        <p class="t-body">Publiek belang boven private winst; inclusief, egalitair en duurzaam.</p>
       </article>
       <article class="c-card c-card--hover">
-        <h3 class="t-subtitle u-m-0">Strategisch &amp; Organisatorisch</h3>
-        <p class="u-m-0 t-body">Europese soevereiniteit, open maar beschermde innovatie, betrouwbaarheid.</p>
+        <h3 class="t-subtitle">Strategisch &amp; Organisatorisch</h3>
+        <p class="t-body">Europese soevereiniteit, open maar beschermde innovatie, betrouwbaarheid.</p>
       </article>
       <article class="c-card c-card--hover">
-        <h3 class="t-subtitle u-m-0">Ideëel &amp; Principieel</h3>
-        <p class="u-m-0 t-body">Talent boven papieren kwalificaties; neutraliteit in conflicten.</p>
+        <h3 class="t-subtitle">Ideëel &amp; Principieel</h3>
+        <p class="t-body">Talent boven papieren kwalificaties; neutraliteit in conflicten.</p>
       </article>
     </div>
   </div>
@@ -67,16 +67,16 @@ slug: "/"
     </div>
     <div class="l-stack">
       <div class="c-card">
-        <h3 class="t-subtitle u-m-0">Transparantie by design</h3>
-        <p class="u-m-0 t-body">Besluiten, jaarrekeningen en uitkeringen worden zichtbaar gepubliceerd.</p>
+        <h3 class="t-subtitle">Transparantie by design</h3>
+        <p class="t-body">Besluiten, jaarrekeningen en uitkeringen worden zichtbaar gepubliceerd.</p>
       </div>
       <div class="c-card">
-        <h3 class="t-subtitle u-m-0">Open samenwerking</h3>
-        <p class="u-m-0 t-body">Netwerk van zelforganiserende cirkels met duidelijke rollen en missietoets.</p>
+        <h3 class="t-subtitle">Open samenwerking</h3>
+        <p class="t-body">Netwerk van zelforganiserende cirkels met duidelijke rollen en missietoets.</p>
       </div>
       <div class="c-card">
-        <h3 class="t-subtitle u-m-0">Mensgericht &amp; veilig</h3>
-        <p class="u-m-0 t-body">AVG-conform, Europese hosting en verantwoorde datapraktijken.</p>
+        <h3 class="t-subtitle">Mensgericht &amp; veilig</h3>
+        <p class="t-body">AVG-conform, Europese hosting en verantwoorde datapraktijken.</p>
       </div>
     </div>
   </div>

--- a/app/pages/klokkenluiders.html
+++ b/app/pages/klokkenluiders.html
@@ -13,7 +13,7 @@ slug: "/klokkenluiders"
     behandelen zorgvuldig en publiceren alleen wat verantwoord is.
   </p>
   <div class="c-alert c-alert--info">
-    <p class="t-small u-m-0">Fase 1: het digitale loket is in voorbereiding. Hieronder vind je de tijdelijke, veilige routes.</p>
+    <p class="t-small">Fase 1: het digitale loket is in voorbereiding. Hieronder vind je de tijdelijke, veilige routes.</p>
   </div>
 </section>
 
@@ -21,9 +21,9 @@ slug: "/klokkenluiders"
 <section class="l-section l-band">
   <div class="l-container l-grid l-grid--auto l-grid--gap-lg">
     <article class="c-card c-card--hover">
-      <h2 class="t-subtitle u-m-0">Interne melding</h2>
-      <p class="t-body u-m-0">Meld bij NederAI zodat we direct kunnen ingrijpen.</p>
-      <ul class="t-small u-text-muted u-m-0 u-mt-sm">
+      <h2 class="t-subtitle">Interne melding</h2>
+      <p class="t-body">Meld bij NederAI zodat we direct kunnen ingrijpen.</p>
+      <ul class="t-small u-text-muted u-mt-sm">
         <li>Ontvangstbevestiging z.s.m. (richtlijn: binnen 7 dagen).</li>
         <li>Terugkoppeling over voortgang (richtlijn: binnen 3 maanden).</li>
         <li>Identiteit blijft vertrouwelijk; delen alleen als strikt nodig.</li>
@@ -35,12 +35,12 @@ slug: "/klokkenluiders"
     </article>
 
     <article class="c-card c-card--hover">
-      <h2 class="t-subtitle u-m-0">Externe melding (toezichthouder)</h2>
-      <p class="t-body u-m-0">
+      <h2 class="t-subtitle">Externe melding (toezichthouder)</h2>
+      <p class="t-body">
         Je mag rechtstreeks melden bij een nationaal erkend toezichthouder. Dit kan passend zijn bij
         (dreigende) ernstige schendingen of als interne melding niet veilig voelt.
       </p>
-      <p class="t-small u-text-muted u-m-0 u-mt-sm">Zie <a href="/documenten#reglementen">reglementen</a> voor actuele gegevens en criteria.</p>
+      <p class="t-small u-text-muted u-mt-sm">Zie <a href="/documenten#reglementen">reglementen</a> voor actuele gegevens en criteria.</p>
     </article>
   </div>
 </section>
@@ -50,7 +50,7 @@ slug: "/klokkenluiders"
   <div class="l-container l-switcher">
     <div class="l-stack">
       <h2 class="t-title">Zo meld je zo veilig mogelijk</h2>
-      <ul class="t-body u-m-0">
+      <ul class="t-body">
         <li>Gebruik bij voorkeur een privé-apparaat en verbinding (geen werkdevice/werknetwerk).</li>
         <li>Versleutel met onze <a href="/keys/nederai-pubkey.asc">PGP-sleutel</a> voor gevoelige bijlagen.</li>
         <li>Deel alleen noodzakelijke persoonsgegevens; anonimiseer waar mogelijk.</li>
@@ -59,8 +59,8 @@ slug: "/klokkenluiders"
     </div>
     <div class="l-stack">
       <div class="c-card">
-        <h3 class="t-subtitle u-m-0">Bescherming melder</h3>
-        <ul class="t-body u-m-0">
+        <h3 class="t-subtitle">Bescherming melder</h3>
+        <ul class="t-body">
           <li>Benadeling of tegenmaatregelen zijn in strijd met onze waarden en worden aangepakt.</li>
           <li>Waar mogelijk kun je <strong>anoniem</strong> melden (PGP/post); we geven praktische instructies.</li>
         </ul>
@@ -73,8 +73,8 @@ slug: "/klokkenluiders"
 <section class="l-section l-band">
   <div class="l-container l-grid l-grid--auto l-grid--gap-lg">
     <article class="c-card">
-      <h2 class="t-subtitle u-m-0">Afhandeling</h2>
-      <ol class="t-body u-m-0">
+      <h2 class="t-subtitle">Afhandeling</h2>
+      <ol class="t-body">
         <li>Ontvangst en voorlopige kwalificatie.</li>
         <li>Onderzoek met zo min mogelijk bekendmaking.</li>
         <li>Maatregelen en beveiliging waar nodig.</li>
@@ -84,9 +84,9 @@ slug: "/klokkenluiders"
     </article>
 
     <article class="c-card">
-      <h2 class="t-subtitle u-m-0">Noodsituaties</h2>
-      <p class="t-body u-m-0">Is er acute dreiging voor veiligheid of gezondheid? Neem direct contact op met de hulpdiensten.</p>
-      <p class="t-small u-text-muted u-m-0">Dit loket is niet bedoeld voor spoed of noodhulp.</p>
+      <h2 class="t-subtitle">Noodsituaties</h2>
+      <p class="t-body">Is er acute dreiging voor veiligheid of gezondheid? Neem direct contact op met de hulpdiensten.</p>
+      <p class="t-small u-text-muted">Dit loket is niet bedoeld voor spoed of noodhulp.</p>
     </article>
   </div>
 </section>
@@ -95,20 +95,20 @@ slug: "/klokkenluiders"
 <section class="l-section">
   <div class="l-container l-grid l-grid--auto l-grid--gap-lg">
     <article class="c-card c-card--hover">
-      <h2 class="t-subtitle u-m-0">Vertrouwelijk e-mailadres</h2>
-      <p class="t-body u-m-0"><a href="mailto:klokkenluiders@neder.ai">klokkenluiders@neder.ai</a></p>
-      <p class="t-small u-text-muted u-m-0">Gebruik PGP voor gevoelige stukken.</p>
+      <h2 class="t-subtitle">Vertrouwelijk e-mailadres</h2>
+      <p class="t-body"><a href="mailto:klokkenluiders@neder.ai">klokkenluiders@neder.ai</a></p>
+      <p class="t-small u-text-muted">Gebruik PGP voor gevoelige stukken.</p>
     </article>
 
     <article class="c-card c-card--hover">
-      <h2 class="t-subtitle u-m-0">Veilige post</h2>
-      <p class="t-body u-m-0">NederAI — t.a.v. Vertrouwelijk Loket<br>Wijchen, Nederland</p>
-      <p class="t-small u-text-muted u-m-0">Stuur geen originelen; gebruik kopieën.</p>
+      <h2 class="t-subtitle">Veilige post</h2>
+      <p class="t-body">NederAI — t.a.v. Vertrouwelijk Loket<br>Wijchen, Nederland</p>
+      <p class="t-small u-text-muted">Stuur geen originelen; gebruik kopieën.</p>
     </article>
 
     <article class="c-card c-card--hover">
-      <h2 class="t-subtitle u-m-0">Persoonlijk gesprek</h2>
-      <p class="t-body u-m-0">Plan een ontmoeting op neutrale locatie.</p>
+      <h2 class="t-subtitle">Persoonlijk gesprek</h2>
+      <p class="t-body">Plan een ontmoeting op neutrale locatie.</p>
       <div class="c-hero__actions u-mt-sm">
         <a class="c-btn c-btn--secondary" href="/contact">Afspraak maken</a>
       </div>

--- a/app/pages/missie-en-waarden.html
+++ b/app/pages/missie-en-waarden.html
@@ -30,8 +30,8 @@ slug: "/missie-en-waarden"
     <div class="l-grid l-grid--auto l-grid--gap-lg">
       <!-- Juridisch & Governance -->
       <article class="c-card c-card--hover">
-        <h3 class="t-subtitle u-m-0">Juridisch &amp; Governance</h3>
-        <ul class="t-body u-m-0">
+        <h3 class="t-subtitle">Juridisch &amp; Governance</h3>
+        <ul class="t-body">
           <li>Volledige openheid en verantwoording.</li>
           <li>Geen dominantie door kapitaal, ideologie of ego.</li>
           <li>Recht dient de mens; terughoudend richting individuen.</li>
@@ -40,8 +40,8 @@ slug: "/missie-en-waarden"
 
       <!-- Maatschappelijk & Ethisch -->
       <article class="c-card c-card--hover">
-        <h3 class="t-subtitle u-m-0">Maatschappelijk &amp; Ethisch</h3>
-        <ul class="t-body u-m-0">
+        <h3 class="t-subtitle">Maatschappelijk &amp; Ethisch</h3>
+        <ul class="t-body">
           <li>Publiek belang eerst; winst is middel, nooit doel.</li>
           <li>Open samenwerking, kennisdeling en inclusiviteit.</li>
           <li>Actieve ruimte voor wie vaak wordt uitgesloten
@@ -53,8 +53,8 @@ slug: "/missie-en-waarden"
 
       <!-- Strategisch & Organisatorisch -->
       <article class="c-card c-card--hover">
-        <h3 class="t-subtitle u-m-0">Strategisch &amp; Organisatorisch</h3>
-        <ul class="t-body u-m-0">
+        <h3 class="t-subtitle">Strategisch &amp; Organisatorisch</h3>
+        <ul class="t-body">
           <li>Subsidiariteit: wat lokaal kan, gebeurt lokaal.</li>
           <li>Versterking van Europese/Nederlandse kennispositie en soevereiniteit.</li>
           <li>Betrouwbaarheid, excellentie en collectieve intelligentie door samenwerken.</li>
@@ -64,8 +64,8 @@ slug: "/missie-en-waarden"
 
       <!-- Ideëel & Principieel -->
       <article class="c-card c-card--hover">
-        <h3 class="t-subtitle u-m-0">Ideëel &amp; Principieel</h3>
-        <ul class="t-body u-m-0">
+        <h3 class="t-subtitle">Ideëel &amp; Principieel</h3>
+        <ul class="t-body">
           <li>Individuen staan centraal; groepslabels geven geen aanspraken.</li>
           <li>Gelijke waardigheid en gelijke kansen voor iedereen.</li>
           <li>Talent, inzet en concrete bijdrage wegen zwaarder dan diploma’s;
@@ -83,7 +83,7 @@ slug: "/missie-en-waarden"
     <h2 class="t-title">Niet onderhandelbaar</h2>
     <div class="l-grid l-grid--auto">
       <div class="c-card">
-        <ul class="t-body u-m-0">
+        <ul class="t-body">
           <li>De waarden gelden voor NederAI en alle groepsonderdelen.</li>
           <li>Besluiten en contracten die ermee in strijd zijn, zijn ongeldig.</li>
           <li>Twijfel? Een erkend toezichthouder kan toetsen, naast de rechterlijke macht.</li>
@@ -98,7 +98,7 @@ slug: "/missie-en-waarden"
   <div class="l-container l-switcher">
     <div class="l-stack">
       <h2 class="t-title">Wat je ervan merkt</h2>
-      <ul class="t-body u-m-0">
+      <ul class="t-body">
         <li><strong>Transparantie by design</strong>: besluiten en jaarcijfers worden publiek gemaakt.</li>
         <li><strong>Missietoets</strong>: elke samenwerking wordt beoordeeld op waardenfit.</li>
         <li><strong>Inclusie in actie</strong>: begeleiding en aanpassingen om talent te laten floreren.</li>
@@ -107,8 +107,8 @@ slug: "/missie-en-waarden"
     </div>
     <div class="l-stack">
       <div class="c-card">
-        <h3 class="t-subtitle u-m-0">Meedoen?</h3>
-        <p class="t-body u-m-0">Deel je onze waarden en wil je AI <em>maken</em> die ertoe doet?
+        <h3 class="t-subtitle">Meedoen?</h3>
+        <p class="t-body">Deel je onze waarden en wil je AI <em>maken</em> die ertoe doet?
           Laten we samenwerken.</p>
         <div class="c-hero__actions u-mt-sm">
           <a class="c-btn" href="/samenwerken">Aanmelden als partner</a>

--- a/app/pages/organisatie.html
+++ b/app/pages/organisatie.html
@@ -19,7 +19,7 @@ slug: "/organisatie"
   <div class="l-container l-switcher">
     <div class="l-stack">
       <h2 class="t-title">Groepsstructuur</h2>
-      <p class="t-body u-m-0">
+      <p class="t-body">
         De groep bestaat uit drie lagen: <strong>Stichting NederAI</strong>, 
         <strong>NederAI Alliance B.V.</strong> (houdster & coördinatie) en werkmaatschappijen:
         <strong>NederAI Institute B.V.</strong> (onderzoek, onderwijs, maatschappelijke projecten) en 
@@ -35,7 +35,7 @@ slug: "/organisatie"
       <figure class="c-imgbox u-aspect-16-9">
         <img src="/assets/org-structure.png" alt="Schematische weergave van de NederAI groep: NederAI → Alliance → Institute & Commercial, met spin-offs" class="c-img--lazy" loading="lazy">
       </figure>
-      <p class="t-small u-m-0 u-text-muted">Indicatief diagram (statisch in fase 1).</p>
+      <p class="t-small u-text-muted">Indicatief diagram (statisch in fase 1).</p>
     </div>
   </div>
 </section>
@@ -45,7 +45,7 @@ slug: "/organisatie"
   <div class="l-container l-switcher">
     <div class="l-stack">
       <h2 class="t-title">Bestuur</h2>
-      <p class="t-body u-m-0">
+      <p class="t-body">
         Het bestuur telt <strong>3–5 natuurlijke personen</strong> en bewaakt missie, waarden en integriteit.
         Oprichter <strong>Bram Luiken</strong> is erkend als <em>Oprichter & Moreel Leider</em> met een
         <strong>niet-bindend</strong> adviesrecht.
@@ -57,8 +57,8 @@ slug: "/organisatie"
     </div>
     <div class="l-stack">
       <div class="c-card">
-        <h3 class="t-subtitle u-m-0">Kernprincipes bestuur</h3>
-        <ul class="t-body u-m-0">
+        <h3 class="t-subtitle">Kernprincipes bestuur</h3>
+        <ul class="t-body">
           <li>Transparantie, integriteit en anti-capture.</li>
           <li>Recht dient de mens; terughoudend richting individuen.</li>
           <li>Neutraliteit in maatschappelijke en geopolitieke conflicten.</li>
@@ -73,7 +73,7 @@ slug: "/organisatie"
   <div class="l-container l-switcher">
     <div class="l-stack">
       <h2 class="t-title">Cirkels &amp; Rollen</h2>
-      <p class="t-body u-m-0">
+      <p class="t-body">
         Teams vormen zich <strong>ad hoc</strong> rondom projecten. Rollen zijn dynamisch, met duidelijke
         verantwoordelijkheden en feedbackloops. Zo benutten we talent en blijven we wendbaar.
       </p>
@@ -85,8 +85,8 @@ slug: "/organisatie"
     </div>
     <div class="l-stack">
       <div class="c-card">
-        <h3 class="t-subtitle u-m-0">Praktisch (fase 1)</h3>
-        <ul class="t-body u-m-0">
+        <h3 class="t-subtitle">Praktisch (fase 1)</h3>
+        <ul class="t-body">
           <li>Statisch overzicht van actieve cirkels en rollen.</li>
           <li>Contactpunt per cirkel voor samenwerking.</li>
           <li>Later: interactieve visualisatie en rolbeheer via intranet.</li>
@@ -113,8 +113,8 @@ slug: "/organisatie"
     </div>
     <div class="l-stack">
       <div class="c-card">
-        <h3 class="t-subtitle u-m-0">Waarom dit werkt</h3>
-        <p class="t-body u-m-0">
+        <h3 class="t-subtitle">Waarom dit werkt</h3>
+        <p class="t-body">
           Duidelijke waarden + transparant proces = sneller vertrouwen, betere samenwerking en minder frictie.
         </p>
       </div>

--- a/app/pages/privacy.html
+++ b/app/pages/privacy.html
@@ -17,24 +17,24 @@ slug: "/privacy"
 <section class="l-section l-band">
   <div class="l-container l-grid l-grid--auto l-grid--gap-lg">
     <article class="c-card c-card--hover">
-      <h2 class="t-subtitle u-m-0">Dataminimalisatie</h2>
-      <ul class="t-body u-m-0">
+      <h2 class="t-subtitle">Dataminimalisatie</h2>
+      <ul class="t-body">
         <li>Alleen gegevens die functioneel noodzakelijk zijn.</li>
         <li>Geen verkoop of uitwisseling voor marketingdoeleinden.</li>
         <li>Bewaartermijnen zo kort mogelijk.</li>
       </ul>
     </article>
     <article class="c-card c-card--hover">
-      <h2 class="t-subtitle u-m-0">Geen onnodige cookies</h2>
-      <ul class="t-body u-m-0">
+      <h2 class="t-subtitle">Geen onnodige cookies</h2>
+      <ul class="t-body">
         <li><strong>Geen</strong> advertentie- of social tracking cookies.</li>
         <li>Functionele cookies alleen voor basiswerking (bijv. taal, sessie).</li>
         <li>Analytics pas na toestemming en privacyvriendelijk geconfigureerd.</li>
       </ul>
     </article>
     <article class="c-card c-card--hover">
-      <h2 class="t-subtitle u-m-0">Europese hosting</h2>
-      <ul class="t-body u-m-0">
+      <h2 class="t-subtitle">Europese hosting</h2>
+      <ul class="t-body">
         <li>Opslag en verwerking binnen de EU/EER.</li>
         <li>Versleuteling in transit en at rest waar passend.</li>
         <li>Toegangsbeheer op basis van rollen en need-to-know.</li>
@@ -48,17 +48,17 @@ slug: "/privacy"
   <div class="l-container l-switcher">
     <div class="l-stack">
       <h2 class="t-title">Welke persoonsgegevens?</h2>
-      <ul class="t-body u-m-0">
+      <ul class="t-body">
         <li><strong>Contact</strong>: naam, e-mail en inhoud van je bericht.</li>
         <li><strong>Samenwerking</strong>: projectinfo en contractgegevens (alleen bij partners).</li>
         <li><strong>Loggegevens</strong>: serverlogs voor veiligheid en foutopsporing.</li>
       </ul>
-      <p class="t-small u-text-muted u-m-0">Geen bijzondere categorieën, tenzij strikt noodzakelijk en met passende waarborgen.</p>
+      <p class="t-small u-text-muted">Geen bijzondere categorieën, tenzij strikt noodzakelijk en met passende waarborgen.</p>
     </div>
     <div class="l-stack">
       <div class="c-card">
-        <h3 class="t-subtitle u-m-0">Rechtsgrond</h3>
-        <ul class="t-body u-m-0">
+        <h3 class="t-subtitle">Rechtsgrond</h3>
+        <ul class="t-body">
           <li>Uitvoering overeenkomst of precontractuele stappen.</li>
           <li>Wettelijke verplichting (bijv. financiële administratie).</li>
           <li>Gerechtvaardigd belang: beveiliging, misbruikpreventie, kwaliteitsverbetering.</li>
@@ -74,7 +74,7 @@ slug: "/privacy"
   <div class="l-container l-switcher">
     <div class="l-stack">
       <h2 class="t-title">Jouw rechten</h2>
-      <ul class="t-body u-m-0">
+      <ul class="t-body">
         <li>Inzage, rectificatie, verwijdering en beperking.</li>
         <li>Bezwaar tegen verwerking op basis van gerechtvaardigd belang.</li>
         <li>Dataportabiliteit voor door jou verstrekte gegevens.</li>
@@ -83,8 +83,8 @@ slug: "/privacy"
     </div>
     <div class="l-stack">
       <div class="c-card">
-        <h3 class="t-subtitle u-m-0">Verzoek indienen</h3>
-        <p class="t-body u-m-0">Mail <a href="mailto:privacy@neder.ai">privacy@neder.ai</a> vanaf het bekende adres. Voor gevoelige verzoeken kun je PGP gebruiken.</p>
+        <h3 class="t-subtitle">Verzoek indienen</h3>
+        <p class="t-body">Mail <a href="mailto:privacy@neder.ai">privacy@neder.ai</a> vanaf het bekende adres. Voor gevoelige verzoeken kun je PGP gebruiken.</p>
         <div class="c-hero__actions u-mt-sm">
           <a class="c-btn c-btn--secondary" href="/keys/nederai-pubkey.asc" download>PGP-sleutel</a>
         </div>
@@ -112,16 +112,16 @@ slug: "/privacy"
 <section class="l-section l-band">
   <div class="l-container l-grid l-grid--auto l-grid--gap-lg">
     <article class="c-card">
-      <h2 class="t-subtitle u-m-0">Bewaartermijnen</h2>
-      <p class="t-body u-m-0">Niet langer dan noodzakelijk: wettelijk (financieel) max. 7 jaar; overige categorieën korter en periodiek opgeschoond.</p>
+      <h2 class="t-subtitle">Bewaartermijnen</h2>
+      <p class="t-body">Niet langer dan noodzakelijk: wettelijk (financieel) max. 7 jaar; overige categorieën korter en periodiek opgeschoond.</p>
     </article>
     <article class="c-card">
-      <h2 class="t-subtitle u-m-0">Delen met derden</h2>
-      <p class="t-body u-m-0">Alleen met verwerkers die aan EU-eisen voldoen en een verwerkersovereenkomst hebben. Geen doorgifte buiten EU zonder passende waarborgen.</p>
+      <h2 class="t-subtitle">Delen met derden</h2>
+      <p class="t-body">Alleen met verwerkers die aan EU-eisen voldoen en een verwerkersovereenkomst hebben. Geen doorgifte buiten EU zonder passende waarborgen.</p>
     </article>
     <article class="c-card">
-      <h2 class="t-subtitle u-m-0">Beveiliging</h2>
-      <p class="t-body u-m-0">TLS, versleutelde opslag waar passend, rolgebaseerde toegang, monitoring en incidentrespons.</p>
+      <h2 class="t-subtitle">Beveiliging</h2>
+      <p class="t-body">TLS, versleutelde opslag waar passend, rolgebaseerde toegang, monitoring en incidentrespons.</p>
     </article>
   </div>
 </section>
@@ -131,12 +131,12 @@ slug: "/privacy"
   <div class="l-container l-switcher">
     <div class="l-stack">
       <h2 class="t-title">Vragen over privacy?</h2>
-      <p class="t-body u-m-0">Mail <a href="mailto:privacy@neder.ai">privacy@neder.ai</a> of schrijf naar: NederAI — Privacy, Wijchen, Nederland.</p>
-      <p class="t-small u-text-muted u-m-0">Voor meldingen over misstanden: ga naar het <a href="/klokkenluiders">klokkenluidersloket</a>.</p>
+      <p class="t-body">Mail <a href="mailto:privacy@neder.ai">privacy@neder.ai</a> of schrijf naar: NederAI — Privacy, Wijchen, Nederland.</p>
+      <p class="t-small u-text-muted">Voor meldingen over misstanden: ga naar het <a href="/klokkenluiders">klokkenluidersloket</a>.</p>
     </div>
     <div class="l-stack">
       <div class="c-alert c-alert--info">
-        <p class="t-small u-m-0">Deze verklaring hoort bij fase 1 (statische site) en wordt bijgewerkt bij nieuwe functionaliteit.</p>
+        <p class="t-small">Deze verklaring hoort bij fase 1 (statische site) en wordt bijgewerkt bij nieuwe functionaliteit.</p>
       </div>
     </div>
   </div>

--- a/app/pages/projecten-nieuws.html
+++ b/app/pages/projecten-nieuws.html
@@ -23,7 +23,7 @@ slug: "/projecten-nieuws"
       <a class="c-badge c-badge--neutral" href="#maatschappelijk">Maatschappelijke projecten</a>
       <a class="c-badge c-badge--neutral" href="#commercieel">Toepassingen (markt)</a>
     </div>
-    <p class="t-small u-text-muted u-m-0">Fase 1: handmatig beheerde lijst, zonder zoekfunctie.</p>
+    <p class="t-small u-text-muted">Fase 1: handmatig beheerde lijst, zonder zoekfunctie.</p>
   </div>
 </section>
 
@@ -36,13 +36,13 @@ slug: "/projecten-nieuws"
       <!-- Projectkaart 1 -->
       <article class="c-card c-card--hover">
         <div class="l-stack">
-          <h3 class="t-kicker u-m-0">Grutto</h3>
-          <h3 class="t-subtitle u-m-0">AI als publieke dienstverlening</h3>
-          <p class="t-body u-m-0">
+          <h3 class="t-kicker">Grutto</h3>
+          <h3 class="t-subtitle">AI als publieke dienstverlening</h3>
+          <p class="t-body">
             Verantwoord ontworpen assistenten die burgers beter helpen zonder datahonger of lock-in.
             Focus: toegankelijkheid, uitlegbaarheid, audittrail.
           </p>
-          <ul class="t-small u-text-muted u-m-0 u-flex u-wrap u-gap-sm">
+          <ul class="t-small u-text-muted u-flex u-wrap u-gap-sm">
             <li>Mensgericht</li><li>Duurzaam</li><li>AVG-conform</li>
           </ul>
         </div>
@@ -51,12 +51,12 @@ slug: "/projecten-nieuws"
       <!-- Projectkaart 2 -->
       <article class="c-card c-card--hover">
         <div class="l-stack">
-            <h3 class="t-kicker u-m-0">Achira</h3>
-            <h3 class="t-subtitle u-m-0">Sociale AI-app als metgezel</h3>
-          <p class="t-body u-m-0">
+            <h3 class="t-kicker">Achira</h3>
+            <h3 class="t-subtitle">Sociale AI-app als metgezel</h3>
+          <p class="t-body">
             Gespreksinhoud verlaat <strong>nooit</strong> het apparaat.
           </p>
-          <ul class="t-small u-text-muted u-m-0 u-flex u-wrap u-gap-sm">
+          <ul class="t-small u-text-muted u-flex u-wrap u-gap-sm">
             <li>Privacy-by-design</li>
             <li>Mensgericht</li>
             <li>Transparant gedrag</li>
@@ -70,12 +70,12 @@ slug: "/projecten-nieuws"
       <!-- Card 2: Volledig zelfstandige genererende AI -->
       <article class="c-card c-card--hover">
         <div class="l-stack">
-            <h3 class="t-kicker u-m-0">Angel</h3>
-            <h3 class="t-subtitle u-m-0">Volledig zelfstandige genererende AI</h3>
-          <p class="t-body u-m-0">
+            <h3 class="t-kicker">Angel</h3>
+            <h3 class="t-subtitle">Volledig zelfstandige genererende AI</h3>
+          <p class="t-body">
             Voert autonoom <strong>grote opdrachten</strong> uit tegen betaling.
           </p>
-          <ul class="t-small u-text-muted u-m-0 u-flex u-wrap u-gap-sm">
+          <ul class="t-small u-text-muted u-flex u-wrap u-gap-sm">
             <li>Multi-step planning</li>
             <li>Tussentijdse rapportage</li>
             <li>Waardenkader afdwingbaar</li>
@@ -88,7 +88,7 @@ slug: "/projecten-nieuws"
     </div>
 
     <div class="c-alert c-alert--info u-mt-sm">
-      <p class="t-small u-m-0">Projecten worden in fase 2 automatisch gepubliceerd vanuit het intranet met besluiten en documentatie.</p>
+      <p class="t-small">Projecten worden in fase 2 automatisch gepubliceerd vanuit het intranet met besluiten en documentatie.</p>
     </div>
   </div>
 </section>
@@ -106,8 +106,8 @@ slug: "/projecten-nieuws"
             <img src="/assets/news-placeholder.jpg" alt="" class="u-object-cover" loading="lazy">
           </div>
           <div>
-            <h3 class="t-subtitle u-m-0"><a href="/projecten-nieuws/intro-nederai">Introductie van NederAI</a></h3>
-            <p class="t-small u-text-muted u-m-0">Aankondiging • publicatie-overzicht en routekaart</p>
+            <h3 class="t-subtitle"><a href="/projecten-nieuws/intro-nederai">Introductie van NederAI</a></h3>
+            <p class="t-small u-text-muted">Aankondiging • publicatie-overzicht en routekaart</p>
             <p class="t-body">We maken AI — transparant, mensgericht en soeverein. Lees wat dat concreet betekent en hoe je kunt meedoen.</p>
           </div>
         </div>
@@ -120,8 +120,8 @@ slug: "/projecten-nieuws"
             <img src="/assets/news-placeholder.jpg" alt="" class="u-object-cover" loading="lazy">
           </div>
           <div>
-            <h3 class="t-subtitle u-m-0"><a href="/projecten-nieuws/roadmap-fase1">Roadmap fase 1 gelanceerd</a></h3>
-            <p class="t-small u-text-muted u-m-0">Roadmap • statische site, documentbibliotheek</p>
+            <h3 class="t-subtitle"><a href="/projecten-nieuws/roadmap-fase1">Roadmap fase 1 gelanceerd</a></h3>
+            <p class="t-small u-text-muted">Roadmap • statische site, documentbibliotheek</p>
             <p class="t-body">Website fase 1 live met Missie & Waarden, Organisatie en Documenten. Volgende stap: intranetkern.</p>
           </div>
         </div>
@@ -139,7 +139,7 @@ slug: "/projecten-nieuws"
   <div class="l-container l-switcher">
     <div class="l-stack">
       <h2 id="maatschappelijk" class="t-title">Een idee dat het publieke belang dient?</h2>
-      <p class="t-body u-m-0">Pitch je project of dataset. We wegen initiatieven langs de Waardenverklaring en bouwen waar het verschil maakt.</p>
+      <p class="t-body">Pitch je project of dataset. We wegen initiatieven langs de Waardenverklaring en bouwen waar het verschil maakt.</p>
       <div class="c-hero__actions">
         <a class="c-btn" href="/samenwerken">Pitch je idee</a>
         <a class="c-btn c-btn--secondary" href="/contact">Contact</a>
@@ -147,9 +147,9 @@ slug: "/projecten-nieuws"
     </div>
     <div class="l-stack">
       <div class="c-card">
-        <h3 id="commercieel" class="t-subtitle u-m-0">Voor professionals</h3>
-        <p class="t-body u-m-0">Samenwerkingen verlopen via een missietoets en duidelijke governance. Transparante planning en publieke rapportage waar passend.</p>
-        <ul class="t-small u-text-muted u-m-0 u-flex u-wrap u-gap-sm u-mt-sm">
+        <h3 id="commercieel" class="t-subtitle">Voor professionals</h3>
+        <p class="t-body">Samenwerkingen verlopen via een missietoets en duidelijke governance. Transparante planning en publieke rapportage waar passend.</p>
+        <ul class="t-small u-text-muted u-flex u-wrap u-gap-sm u-mt-sm">
           <li>Missietoets</li><li>Contracten met waardenkader</li><li>Publieke voortgang</li>
         </ul>
       </div>

--- a/app/pages/samenwerken.html
+++ b/app/pages/samenwerken.html
@@ -22,23 +22,23 @@ slug: "/samenwerken"
 <section class="l-section l-band">
   <div class="l-container l-grid l-grid--auto l-grid--gap-lg">
     <article class="c-card c-card--hover">
-      <h2 class="t-subtitle u-m-0">Publieke sector</h2>
-      <p class="t-body u-m-0">Ministeries, gemeenten, uitvoeringsorganisaties: mensgerichte AI, uitlegbaar en AVG-conform.</p>
-      <ul class="t-small u-text-muted u-m-0 u-flex u-wrap u-gap-sm u-mt-sm">
+      <h2 class="t-subtitle">Publieke sector</h2>
+      <p class="t-body">Ministeries, gemeenten, uitvoeringsorganisaties: mensgerichte AI, uitlegbaar en AVG-conform.</p>
+      <ul class="t-small u-text-muted u-flex u-wrap u-gap-sm u-mt-sm">
         <li>Open standaarden</li><li>Audittrail</li><li>Soeverein</li>
       </ul>
     </article>
     <article class="c-card c-card--hover">
-      <h2 class="t-subtitle u-m-0">Onderwijs &amp; onderzoek</h2>
-      <p class="t-body u-m-0">Samen curriculum, labs en datasets ontwikkelen; studenten en onderzoekers bouwen mee.</p>
-      <ul class="t-small u-text-muted u-m-0 u-flex u-wrap u-gap-sm u-mt-sm">
+      <h2 class="t-subtitle">Onderwijs &amp; onderzoek</h2>
+      <p class="t-body">Samen curriculum, labs en datasets ontwikkelen; studenten en onderzoekers bouwen mee.</p>
+      <ul class="t-small u-text-muted u-flex u-wrap u-gap-sm u-mt-sm">
         <li>Open science</li><li>Herproduceerbaarheid</li><li>Public value</li>
       </ul>
     </article>
     <article class="c-card c-card--hover">
-      <h2 class="t-subtitle u-m-0">Bedrijven &amp; startups</h2>
-      <p class="t-body u-m-0">Toepassingen met maatschappelijk nut, zonder lock-in of ethics washing.</p>
-      <ul class="t-small u-text-muted u-m-0 u-flex u-wrap u-gap-sm u-mt-sm">
+      <h2 class="t-subtitle">Bedrijven &amp; startups</h2>
+      <p class="t-body">Toepassingen met maatschappelijk nut, zonder lock-in of ethics washing.</p>
+      <ul class="t-small u-text-muted u-flex u-wrap u-gap-sm u-mt-sm">
         <li>Governance</li><li>Duidelijke IP-afspraken</li><li>Fair value</li>
       </ul>
     </article>
@@ -50,7 +50,7 @@ slug: "/samenwerken"
   <div class="l-container l-switcher">
     <div class="l-stack">
       <h2 class="t-title">Missietoets (fase 1)</h2>
-      <p class="t-body u-m-0">Korte toets om waardenfit en publiek nut te borgen. Samenwerking gaat door als:</p>
+      <p class="t-body">Korte toets om waardenfit en publiek nut te borgen. Samenwerking gaat door als:</p>
       <ul class="t-body">
         <li>Het <strong>publieke belang</strong> aantoonbaar wordt gediend.</li>
         <li>Er <strong>geen dominantie</strong> is door kapitaal, ideologie of ego.</li>
@@ -61,8 +61,8 @@ slug: "/samenwerken"
     </div>
     <div class="l-stack">
       <div class="c-card">
-        <h3 class="t-subtitle u-m-0">Niet passend</h3>
-        <ul class="t-body u-m-0">
+        <h3 class="t-subtitle">Niet passend</h3>
+        <ul class="t-body">
           <li>Winst als primair doel zonder publiek nut.</li>
           <li>Vendor lock-in of ondoorzichtige datapraktijken.</li>
           <li>Politieke instrumentalisering of agitprop.</li>
@@ -76,16 +76,16 @@ slug: "/samenwerken"
 <section class="l-section l-band">
   <div class="l-container l-grid l-grid--auto l-grid--gap-lg">
     <article class="c-card c-card--hover">
-      <h2 class="t-subtitle u-m-0">Pilot / Proefopstelling</h2>
-      <p class="t-body u-m-0">Kleine scope, meetbare uitkomst, snelle feedback. Publicatie van resultaten waar mogelijk.</p>
+      <h2 class="t-subtitle">Pilot / Proefopstelling</h2>
+      <p class="t-body">Kleine scope, meetbare uitkomst, snelle feedback. Publicatie van resultaten waar mogelijk.</p>
     </article>
     <article class="c-card c-card--hover">
-      <h2 class="t-subtitle u-m-0">Project / Implementatie</h2>
-      <p class="t-body u-m-0">Heldere governance, risicobeheersing en audittrail. Open waar het kan, beschermd waar het moet.</p>
+      <h2 class="t-subtitle">Project / Implementatie</h2>
+      <p class="t-body">Heldere governance, risicobeheersing en audittrail. Open waar het kan, beschermd waar het moet.</p>
     </article>
     <article class="c-card c-card--hover">
-      <h2 class="t-subtitle u-m-0">Kennis &amp; onderwijs</h2>
-      <p class="t-body u-m-0">Gastcolleges, minoren, labs en open leermaterialen met praktijkimpact.</p>
+      <h2 class="t-subtitle">Kennis &amp; onderwijs</h2>
+      <p class="t-body">Gastcolleges, minoren, labs en open leermaterialen met praktijkimpact.</p>
     </article>
   </div>
 </section>
@@ -95,17 +95,17 @@ slug: "/samenwerken"
   <div class="l-container l-switcher">
     <div class="l-stack">
       <h2 class="t-title">Start hier</h2>
-      <p class="t-body u-m-0">Stuur een korte pitch (doel, publiek nut, data, planning). We reageren snel met een voorlopige missietoets.</p>
+      <p class="t-body">Stuur een korte pitch (doel, publiek nut, data, planning). We reageren snel met een voorlopige missietoets.</p>
       <div class="c-hero__actions">
         <a class="c-btn" href="mailto:info@neder.ai?subject=Pitch%20samenwerking%20NederAI">Pitch per e-mail</a>
         <a class="c-btn c-btn--secondary" href="/contact">Contactgegevens</a>
       </div>
-      <p class="t-small u-text-muted u-m-0">Fase 1: e-mailintake. Fase 2–3: formulier + automatische publicatie van besluiten.</p>
+      <p class="t-small u-text-muted">Fase 1: e-mailintake. Fase 2–3: formulier + automatische publicatie van besluiten.</p>
     </div>
     <div class="l-stack">
       <div class="c-card">
-        <h3 class="t-subtitle u-m-0">Checklist bij je pitch</h3>
-        <ul class="t-body u-m-0">
+        <h3 class="t-subtitle">Checklist bij je pitch</h3>
+        <ul class="t-body">
           <li>Probleem &amp; gewenste uitkomst (meetbaar).</li>
           <li>Publiek belang &amp; risico’s (incl. mitigatie).</li>
           <li>Data &amp; infrastructuur (herkomst, AVG, EU-hosting).</li>


### PR DESCRIPTION
## Summary
- remove `u-m-0` utility class from static HTML pages, leaving layout unaffected

## Testing
- `php -l app/pages/*.html`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b82f88892883228d3a3f9ffde91dfb